### PR TITLE
Removing malicious and no longer in use PWA directories

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,12 +211,9 @@
 				<li>Build upon the PWA by adding HTML, CSS, and Javascript.</li>
 			</ol>
 			<h2 class="more">Where can I find other PWAs?</h2>
-			<p>Looking for inspiration? Check out these PWA directories:</p>
+			<p>Looking for inspiration? Check out:</p>
 			<ul>
-				<li><a href="https://pwainside.com/" target="_blank" rel="noopener nofollow">PWA Inside</a></li>
 				<li><a href="https://appsco.pe/" target="_blank" rel="noopener nofollow">Appscope</a></li>
-				<li><a href="https://progressiveapp.store/" target="_blank" rel="noopener nofollow">Progressive App Store</a></li>
-				<li><a href="https://pwa-directory.appspot.com/" target="_blank" rel="noopener nofollow">PWA Directory</a></li>
 			</ul>
 			<h2 class="help">Can I contribute?</h2>
 			<p>Want to help improve this? Contributions are welcome! <span class="icon arrow" role="img" aria-label="Arrow">&#x27A1;&#xFE0F;</span>&nbsp;<a href="https://github.com/nikkifurls/simple-pwa" target="_blank" rel="nofollow noopener">GitHub</a></p>


### PR DESCRIPTION
Removing malicious and no longer in use links

Two of the links were just dead or going to domain parking pages, one of them popped up with a scammy alert.